### PR TITLE
Grab signed URLs if dataset is private - refs #129

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,8 +17,8 @@ class DataHubApi {
   }
 
   // Get a datapackage.json including its readme inline (if readme exists)
-  async getPackage(ownerid, name) {
-    const res = await this.getPackageFile(ownerid, name)
+  async getPackage(ownerid, name, token=null) {
+    const res = await this.getPackageFile(ownerid, name, 'datapackage.json', token)
     if (res.status !== 200) {
       // eslint-disable-next-line no-throw-literal
       throw {
@@ -40,7 +40,7 @@ class DataHubApi {
 
     // We might already have readme set - e.g. if it has already been inlined ...
     if (!dp.readme) {
-      const readmeRes = await this.getPackageFile(ownerid, name, 'README.md')
+      const readmeRes = await this.getPackageFile(ownerid, name, 'README.md', token)
       // ignore 404s etc
       if (readmeRes.status === 200) {
         dp.readme = await readmeRes.text()
@@ -78,12 +78,24 @@ class DataHubApi {
     })
   }
 
-  async getPackageFile(ownerid, name, path = 'datapackage.json') {
+  async getPackageFile(ownerid, name, path = 'datapackage.json', token=null) {
     const url = urllib.resolve(this.bitstoreUrl,
         [ownerid, name, 'latest', path].join('/')
         )
-    const response = await fetch(url)
+    let response = await fetch(url)
+    if (response.status === 403) {
+      const signedUrl = await this.checkForSignedUrl(url, ownerid, token)
+      response = await fetch(signedUrl.url)
+    }
     return response
+  }
+
+  async checkForSignedUrl(url, ownerid, token) {
+    const urlToChek = urllib.resolve(
+        this.DATAHUB_API, `rawstore/presign?jwt=${token}&ownerid=${ownerid}&url=${url}`
+        )
+    const response = await fetch(urlToChek)
+    return response.json()
   }
 
   async search(query, token) {

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -13,6 +13,8 @@ module.exports.initMocks = function() {
     .persist()
     .get('/admin/demo-package/latest/datapackage.json')
     .reply(200, data.dataPackage, {'access-control-allow-origin': '*'})
+    .get('/admin/private-package/latest/datapackage.json')
+    .reply(403, {})
     .get('/admin/demo-package/latest/README.md')
     .reply(200, data.readme, {'access-control-allow-origin': '*'})
     .get('/bad-user/bad-package/latest/datapackage.json')
@@ -48,6 +50,13 @@ module.exports.initMocks = function() {
 
   // Mock api calls for Metastore (search)
   // TODO: 2017-08-11 ~rufuspollock construct extended DP ourselves from an input fixture package so that we can test more cleanly
+  nock(config.get('API_URL'))
+    .persist()
+    .get('/rawstore/presign?jwt=token&ownerid=admin&url=http://127.0.0.1:4000/static/fixtures/admin/private-package/latest/datapackage.json')
+    .reply(200, {
+        "url": config.get('BITSTORE_URL')+"admin/demo-package/latest/datapackage.json"
+      })
+
   const extendedDp = require('./extended-dp/datapackage.json')
   nock(config.get('API_URL'))
     .persist()

--- a/tests/lib.test.js
+++ b/tests/lib.test.js
@@ -15,6 +15,15 @@ test('Gets datapackage.json (as extended)', async t => {
   t.is(dpjson.resources.length, 4)
 })
 
+test('Gets datapackage.json signedUrl', async t => {
+  let res = await api.getPackageFile(
+      'admin', 'private-package', 'datapackage.json', 'token')
+  let dpjson = await res.json()
+  t.is(dpjson.name, 'demo-package')
+  t.is(dpjson.datahub.findability, 'published')
+  t.is(dpjson.resources.length, 4)
+})
+
 test("Generates logical dp from extended dp", async t => {
 	const extended = require('./fixtures/extended-dp/datapackage.json')
 	const logical = lib.DataHubApi.extendedToLogical(extended)


### PR DESCRIPTION
This PR allows requesting signed URLs for private datasets and does not allow others to see ones Private dataset. 

* request "regular" URL for dp.json 
* if s3 responds with 403 frontend requests  signed URL from bitstore
* after getting signed URLs iterates over resources and updates resource paths with signed URLs (same approach)

Includes tests