### PR TITLE
Allow loading showcase page for private dataset or 404 if necessary 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,6 +84,9 @@ class DataHubApi {
         )
     let response = await fetch(url)
     if (response.status === 403) {
+      if (!token) {
+        throw { name: 'Forbidden', message: `Not allowed`, res: response }
+      }
       const signedUrl = await this.checkForSignedUrl(url, ownerid, token)
       response = await fetch(signedUrl.url)
     }
@@ -95,6 +98,9 @@ class DataHubApi {
         this.DATAHUB_API, `rawstore/presign?jwt=${token}&ownerid=${ownerid}&url=${url}`
         )
     const response = await fetch(urlToChek)
+    if (response.status !== 200) {
+      throw { name: 'Forbidden', message: `Not allowed`, res: response }
+    }
     return response.json()
   }
 
@@ -144,6 +150,18 @@ class DataHubApi {
     const response = await fetch(url)
     const out = await response.json()
     return out
+  }
+
+  async authz(token, service='frontend') {
+    const options = token ? {headers: {'Auth-Token': token}} : null
+    const res = await fetch(
+        `${this.AUTH_API}/auth/authorize?service=${service}`,
+        options
+    )
+    if (res.status !== 200) {
+      return null
+    }
+    return (await res.json()).token
   }
 
   /**

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -56,6 +56,15 @@ module.exports.initMocks = function() {
     .reply(200, {
         "url": config.get('BITSTORE_URL')+"admin/demo-package/latest/datapackage.json"
       })
+  nock(config.get('API_URL'), {reqheaders: {'Auth-Token': 'token'}})
+    .persist()
+    .get('/auth/authorize?service=frontend')
+    .reply(200, {"token": "simple-token"})
+
+  nock(config.get('API_URL'), {reqheaders: {'Auth-Token': 'private-token'}})
+    .persist()
+    .get('/auth/authorize?service=frontend')
+    .reply(200, {"token": "token"})
 
   const extendedDp = require('./extended-dp/datapackage.json')
   nock(config.get('API_URL'))
@@ -282,5 +291,10 @@ module.exports.initMocks = function() {
     .reply(200, {
       userid: 'core',
       packageid: 'gold-prices'
+    })
+    .get('/resolve?path=admin/private-package')
+    .reply(200, {
+      userid: 'admin',
+      packageid: 'private-package'
     })
 }

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -53,6 +53,39 @@ test('Showcase page returns 200 and has correct content', async t => {
   t.true(res.text.includes('DataHub'))
 })
 
+test('Showcase page returns 200 if logged in', async t => {
+  const res = await request(app)
+    .get('/admin/demo-package')
+    .set('Cookie', ['jwt=token'])
+    .expect(200)
+  t.is(res.statusCode, 200)
+  t.true(res.text.includes('DataHub'))
+})
+
+test('Showcase page returns 200 if logged in and private dataset', async t => {
+  const res = await request(app)
+    .get('/admin/private-package')
+    .set('Cookie', ['jwt=private-token'])
+    .expect(200)
+  t.is(res.statusCode, 200)
+  t.true(res.text.includes('DataHub'))
+})
+
+test('Showcase page returns 404 not logged in and private dataset', async t => {
+  const res = await request(app)
+    .get('/admin/private-package')
+    .expect(404)
+  t.is(res.statusCode, 404)
+})
+
+test('Showcase page returns 404 if logged in but not owns private dataset', async t => {
+  const res = await request(app)
+    .get('/admin/private-package')
+    .set('Cookie', ['jwt=token'])
+    .expect(404)
+  t.is(res.statusCode, 404)
+})
+
 test('Showcase page has readme, title and publisher in content', async t => {
   const res = await request(app)
     .get('/admin/demo-package')
@@ -129,6 +162,29 @@ test('"API" for datapackage.json file', async t => {
     .get('/admin/demo-package/datapackage.json')
   t.is(res.statusCode, 302)
   t.true(res.header.location.includes('/latest/datapackage.json'))
+})
+
+test('"API" for datapackage.json returns 302 if logged in', async t => {
+  const res = await request(app)
+    .get('/admin/demo-package/datapackage.json')
+    .set('Cookie', ['jwt=token'])
+  t.is(res.statusCode, 302)
+  t.true(res.header.location.includes('/latest/datapackage.json'))
+})
+
+test('"API" for datapackage.json works if logged in and private dataset', async t => {
+  const res = await request(app)
+    .get('/admin/private-package/datapackage.json')
+    .set('Cookie', ['jwt=private-token'])
+  t.is(res.statusCode, 302)
+  t.true(res.header.location.includes('/latest/datapackage.json'))
+})
+
+test('"API" for datapackage.json returns 404 not logged in and private dataset', async t => {
+  const res = await request(app)
+    .get('/admin/private-package/datapackage.json')
+    .expect(404)
+  t.is(res.statusCode, 404)
 })
 
 test('Downloading a resource by name or index works for csv and json', async t => {


### PR DESCRIPTION
Showcase page will load only in case jwt from cookies is authenticated. In case not logged in or logged in but jwt does not match with owners renders 404

* function for getting auth token
* render private datasets if jwt from cookies match
* render 404 if not logged in or jwt does not match
* moks and tests