### PR TITLE
display validation for excel sheet - refs #169

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -401,9 +401,14 @@ class DataHubApi {
        response = await fetch(signedUrl.url)
        out = await response.json()
      }
-
      out.forEach(report => {
-       const resourceForThisReport = dp.resources.find(res => res.name === report.resource)
+       const resourceForThisReport = dp.resources.find(res => {
+         // In case of xls or xslx aditional resource is added with sufix '-sheet-1' By CLI
+         // That resource is not included in orignal descriptor as should be added later when processed
+         // While validation is performed on resource with `sheet-1` we can not find match
+         // So as temporary solution we are hardcoding it right now.
+         return res.name === report.resource || res.name+'-sheet-1' === report.resource
+       })
        if (resourceForThisReport) {
          resourceForThisReport.report = JSON.stringify(report).replace(/\\"/g, "").replace(/\"/g, "\\\"")
        }

--- a/lib/index.js
+++ b/lib/index.js
@@ -403,10 +403,10 @@ class DataHubApi {
      }
      out.forEach(report => {
        const resourceForThisReport = dp.resources.find(res => {
-         // In case of xls or xslx aditional resource is added with sufix '-sheet-1' By CLI
-         // That resource is not included in orignal descriptor as should be added later when processed
+         // In case of xls or xslx additional resource is added with suffix '-sheet-1' By CLI
+         // That resource is not included in original descriptor as should be added later when processed
          // While validation is performed on resource with `sheet-1` we can not find match
-         // So as temporary solution we are hardcoding it right now.
+         // So as the temporary solution we are hardcoding it right now.
          return res.name === report.resource || res.name+'-sheet-1' === report.resource
        })
        if (resourceForThisReport) {


### PR DESCRIPTION
In case of `xls` or `xslx` additional resource is added with suffix '-sheet-1' by CLI. That resource is not included in original descriptor as should be added later when processed, while validation is performed on the resource with `sheet-1`  we can not find a match. So as the temporary solution, we are hardcoding it right now. 

For example, while `dp.json` may look like this:

```
"name": "my-datasets",
"resources": [
  {
    "format": "xls",
    "name": "my-excel",
   }
],
```

Validation is performed on resource named `my-excel-sheet-1`.

So when trying to find match for resource name in descriptor and resource name in the validation report  it always evaluates to false 