### PR TITLE
Per view URLs

### DIFF
--- a/tests/fixtures/demo-package/datapackage.json
+++ b/tests/fixtures/demo-package/datapackage.json
@@ -288,6 +288,7 @@
   "version": "0.1.0",
   "views": [
     {
+      "name": "graph",
       "id": "Graph",
       "state": {
         "graphType": "lines",

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -164,7 +164,6 @@ test('"API" for datapackage.json works if logged in and private dataset', async 
 test('"API" for datapackage.json returns 404 not logged in and private dataset', async t => {
   const res = await request(app)
     .get('/admin/private-package/datapackage.json')
-    .expect(404)
   t.is(res.statusCode, 404)
 })
 
@@ -185,6 +184,23 @@ test('Downloading a resource by name or index works for csv and json', async t =
     .get('/admin/demo-package/r/0.json')
   t.is(res.statusCode, 302)
   t.true(res.header.location.includes('_json.json'))
+})
+
+test('Per view URLs work', async t => {
+  // By index:
+  let res = await request(app)
+    .get('/admin/demo-package/view/0')
+  t.is(res.statusCode, 200)
+  t.true(res.text.includes('<!-- Views -->'))
+  // By name:
+  res = await request(app)
+    .get('/admin/demo-package/view/graph')
+  t.is(res.statusCode, 200)
+  t.true(res.text.includes('<!-- Views -->'))
+  // 404:
+  res = await request(app)
+    .get('/admin/demo-package/view/1')
+  t.is(res.statusCode, 404)
 })
 
 test('Events page works', async t => {

--- a/views/view.html
+++ b/views/view.html
@@ -1,0 +1,13 @@
+<!-- Views -->
+<div class="react-me part" data-type="data-views"></div>
+<div class="react-me tables" data-type="resource-preview" data-resource="0"></div>
+
+{% block scripts %}
+  <!-- pass DP_ID to frontend -->
+  <script type="text/javascript">
+   var DP_ID = JSON.parse('{{ dpId | safe }}');
+  </script>
+
+  <link rel="stylesheet" media="screen" href="/static/dpr-js/dist/main.css">
+  <script type="text/javascript" src="/static/dpr-js/dist/bundle.js"></script>
+{% endblock %}


### PR DESCRIPTION
Implemented per view URLs feature so now users can access each view by index or name. This will allow users to embed a view into another website or page.

Let's consider this example https://datahub.io/core/household-income-us-historical. The dataset has 2 graphs + 1 preview table. You need to know either index or name of the view you want to access. If you take a look at `datapackage.json` of the dataset https://datahub.io/core/household-income-us-historical/datapackage.json you'd see that there are 3 view objects in the `views` property. So the URLs would be:

- first view
  - by index: https://datahub.io/core/household-income-us-historical/view/0
  - by name: https://datahub.io/core/household-income-us-historical/view/comparison-of-upper-limit-of-each-fifth-and-lower-limit-of-top-5-percent
- second view
  - by index: https://datahub.io/core/household-income-us-historical/view/1
  - by name: https://datahub.io/core/household-income-us-historical/view/lowest-fifth-vs-top-5-percent
- third view
  - by index: https://datahub.io/core/household-income-us-historical/view/2
  - by name: https://datahub.io/core/household-income-us-historical/view/datahub-preview-household-income-us-historical_csv_preview