### PR TITLE
fixed instructions for Python (failed when source data were invalid)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "start dev": "export API_URL=https://api-testing.datahub.io; export BITSTORE_URL=https://pkgstore-testing.datahub.io; node index.js",
+    "start dev": "export API_URL=https://api.datahub.io; export BITSTORE_URL=https://pkgstore.datahub.io; node index.js",
     "test": "ava -v",
     "watch:test": "npm run test -- --watch",
     "lint": "xo --quite"

--- a/views/_instructions.html
+++ b/views/_instructions.html
@@ -52,16 +52,13 @@ resources = package.resources
 
 package = Package(<span class="hljs-string">'https://datahub.io/{{dataset.datahub.owner}}/{{dataset.name}}/datapackage.json'</span>)
 
-<span class="hljs-comment"># get list of all resources:</span>
-resources = package.descriptor[<span class="hljs-string">'resources'</span>]
-resourceList = [resources[x][<span class="hljs-string">'name'</span>] <span class="hljs-keyword">for</span> x <span class="hljs-keyword">in</span> range(<span class="hljs-number">0</span>, len(resources))]
-print(resourceList)
+<span class="hljs-comment"># print list of all resources:</span>
+<span class="hljs-keyword">print</span>(package.resource_names)
 
-<span class="hljs-comment"># print all tabular data(if exists any)</span>
-resources = package.resources
-<span class="hljs-keyword">for</span> resource <span class="hljs-keyword">in</span> resources:
+<span class="hljs-comment"># print processed tabular data (if exists any)</span>
+<span class="hljs-keyword">for</span> resource <span class="hljs-keyword">in</span> package.resources:
     <span class="hljs-keyword">if</span> resource.descriptor['datahub']['type'] == 'derived/csv':
-        print(resource.read())
+        <span class="hljs-keyword">print</span>(resource.read())
 </code></pre>
 {%- endmacro %}
 

--- a/views/_instructions.html
+++ b/views/_instructions.html
@@ -60,7 +60,7 @@ print(resourceList)
 <span class="hljs-comment"># print all tabular data(if exists any)</span>
 resources = package.resources
 <span class="hljs-keyword">for</span> resource <span class="hljs-keyword">in</span> resources:
-    <span class="hljs-keyword">if</span> resource.tabular:
+    <span class="hljs-keyword">if</span> resource.descriptor['datahub']['type'] == 'derived/csv':
         print(resource.read())
 </code></pre>
 {%- endmacro %}


### PR DESCRIPTION
issue: https://github.com/datahq/datahub-qa/issues/143

Before we printed all tabular resources, but some datasets have invalid data in source files, those caused Exceptions.
Now we print only derived/csv data that were processed by datahub.io and is definitely valid.