### PR TITLE
[analystics][s]: track logins from CLI and Web -refs #248

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -208,7 +208,7 @@ class DataHubApi {
   }
 
   async authenticate(jwt) {
-    const url = `${this.AUTH_API}/auth/check?jwt=${jwt}&next=${this.baseUrl}/success`
+    const url = `${this.AUTH_API}/auth/check?jwt=${jwt}&next=${this.baseUrl}/success?client=web`
     const response = await fetch(url)
     const out = await response.json()
     return out

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -176,7 +176,7 @@ module.exports.initMocks = function() {
   // Not authenticated returns urls for login
   nock(config.get('API_URL'))
     .persist()
-    .get(`/auth/check?jwt=undefined&next=${config.get('SITE_URL')}/success`)
+    .get(`/auth/check?jwt=undefined&next=${config.get('SITE_URL')}/success?client=web`)
     .reply(200, {
       "authenticated": false,
       "providers": {
@@ -191,7 +191,7 @@ module.exports.initMocks = function() {
   // GitHub
   nock(config.get('API_URL'))
     .persist()
-    .get(`/auth/check?jwt=1a2b3c&next=${config.get('SITE_URL')}/success`)
+    .get(`/auth/check?jwt=1a2b3c&next=${config.get('SITE_URL')}/success?client=web`)
     .reply(200, {
       "authenticated": true,
       "profile": {
@@ -207,7 +207,7 @@ module.exports.initMocks = function() {
   // GOOGLE
   nock(config.get('API_URL'))
     .persist()
-    .get(`/auth/check?jwt=1a2b3c4d&next=${config.get('SITE_URL')}/success`)
+    .get(`/auth/check?jwt=1a2b3c4d&next=${config.get('SITE_URL')}/success?client=web`)
     .reply(200, {
       "authenticated": true,
       "profile": {

--- a/views/base.html
+++ b/views/base.html
@@ -20,7 +20,7 @@
     var trackOutboundLink = function(url) {
        ga('send', 'event', 'outbound', 'click', url, {
          'transport': 'beacon',
-         'hitCallback': function(){document.location = url;}
+         'hitCallback': function(){}
        });
     }
   </script>

--- a/views/base.html
+++ b/views/base.html
@@ -11,6 +11,36 @@
   <meta name="keywords" content="data,datasets,data publishing,data sharing,data hosting,data package,reference data,indicators">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <link rel="icon" type="img/ico" href="/static/img/favicon.ico" sizes="16x16">
+  <!-- As recommended by GA following snippet should be placed near the top of the <head> tag and before any other script or CSS tags -->
+  <!-- Google Analytics -->
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-80458846-4', 'auto');
+
+    function getCookie(name) {
+      var value = "; " + document.cookie;
+      var parts = value.split("; " + name + "=");
+      if (parts.length == 2) return parts.pop().split(";").shift();
+    }
+
+    '{% if login %}'
+      var userid = getCookie('id');
+      if (userid) {
+        ga('set', 'userId', userid); // Set the user ID using signed-in user_id.
+      }
+    '{% endif %}'
+
+    // If experiment data is set then send it to GA:
+    if ('{{expId}}' && '{{expVar}}') {
+      ga('set', 'exp', '{{expId}}.{{expVar}}');
+    }
+    ga('send', 'pageview');
+  </script>
+  <!-- End Google Analytics -->
   <link rel="stylesheet" media="screen" href="/static/stylesheets/app.css">
   <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.css">
@@ -19,8 +49,7 @@
   <script>
     var trackOutboundLink = function(url) {
        ga('send', 'event', 'outbound', 'click', url, {
-         'transport': 'beacon',
-         'hitCallback': function(){}
+         'transport': 'beacon'
        });
     }
   </script>
@@ -184,38 +213,11 @@
         });
       });
       // Set avatar in navbar using id in cookies
-      function getCookie(name) {
-        var value = "; " + document.cookie;
-        var parts = value.split("; " + name + "=");
-        if (parts.length == 2) return parts.pop().split(";").shift();
-      }
       var src = `https://www.gravatar.com/avatar/${getCookie('id')}?d=https%3A%2F%2Ftesting.datahub.io%2Fstatic%2Fimg%2Flogo-cube03.png`;
       var avatar = document.getElementById('avatar');
       if (avatar) {
         avatar.src = src;
       }
-    </script>
-
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-80458846-4', 'auto');
-
-      '{% if login %}'
-        var userid = getCookie('id');
-        if (userid) {
-          ga('set', 'userId', userid); // Set the user ID using signed-in user_id.
-        }
-      '{% endif %}'
-
-      // If experiment data is set then send it to GA:
-      if ('{{expId}}' && '{{expVar}}') {
-        ga('set', 'exp', '{{expId}}.{{expVar}}');
-      }
-      ga('send', 'pageview');
     </script>
   </body>
 

--- a/views/dashboard.html
+++ b/views/dashboard.html
@@ -7,6 +7,7 @@ Dashboard
 {% block bodyclass %}dashboard{% endblock %}
 
 {% block content %}
+<body onload="trackOutboundLink('{{client}}')">
 <div class="container">
   <div class="inner_container">
     <div class="alert alert-info" role="alert">
@@ -78,4 +79,5 @@ Dashboard
     {% endif %}
   </div>
 </div>
+</body>
 {% endblock %}

--- a/views/dashboard.html
+++ b/views/dashboard.html
@@ -7,7 +7,6 @@ Dashboard
 {% block bodyclass %}dashboard{% endblock %}
 
 {% block content %}
-<body onload="trackOutboundLink('{{client}}')">
 <div class="container">
   <div class="inner_container">
     <div class="alert alert-info" role="alert">
@@ -79,5 +78,10 @@ Dashboard
     {% endif %}
   </div>
 </div>
-</body>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  trackOutboundLink('{{client}}');
+</script>
 {% endblock %}


### PR DESCRIPTION
* wrapped template inside <body> to call the outbound function on load
* removed redirection part from the callback handler as it seems redundant (and actually redirects when not needed)
* 3 types of events: login-cli, login-web, dashboard-check