### PR TITLE
[publisher-search][xs]: removed query string on form which appears af…

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -1026,7 +1026,6 @@ module.exports = function () {
     const size = req.query.size || 20
     const query = req.query.q ? `&q="${req.query.q}"` : ""
     const packages = await api.search(`datahub.ownerid="${userProfile.profile.id}"${query}&size=${size}&from=${from}`, token)
-    const queryString = req.query.q ? `&q=${req.query.q}` : ""
     const total = packages.summary.total
     const totalPages = Math.ceil(total/size)
     const currentPage = parseInt(from, 10) / 20 + 1
@@ -1041,7 +1040,8 @@ module.exports = function () {
       joinDate: joinMonth + ' ' + joinYear,
       owner: req.params.owner,
       name: userProfile.profile.name,
-      queryString: queryString
+      queryString: req.query.q || '',
+      query
     })
   })
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -1041,7 +1041,7 @@ module.exports = function () {
       joinDate: joinMonth + ' ' + joinYear,
       owner: req.params.owner,
       name: userProfile.profile.name,
-      query: queryString
+      queryString: queryString
     })
   })
 

--- a/views/owner.html
+++ b/views/owner.html
@@ -60,7 +60,7 @@
           </div>
           <div class="col-sm-6">
             <form class="search-form form form-inline" class="input-group col-xs-12" action="/{{ owner }}" method="GET">
-              <input type="text" class="form-control" placeholder="Search..." name="q" value="{{ query }}" required/>
+              <input type="text" class="form-control" placeholder="Search..." name="q" value="{{ queryString }}" required/>
             </form>
           </div>
         </div>
@@ -73,7 +73,7 @@
               <nav aria-label="Datasets">
                 <ul class="pagination">
                   <li class="page-item">
-                    <a class="page-link" href="/{{ owner }}?from=0{{queryString}}" aria-label="Previous">
+                    <a class="page-link" href="/{{ owner }}?from=0{{ query }}" aria-label="Previous">
                       <span aria-hidden="true">&laquo;</span>
                       <span class="sr-only">Previous</span>
                     </a>
@@ -82,12 +82,12 @@
                     {% if page == '...' %}
                     <li class="page-item disabled"><span class="page-link">{{page}}</span></li>
                     {% else %}
-                    <li class="page-item {{ 'current-page' if currentPage == page }}"><a class="page-link" href="/{{ owner }}?from={{ (page - 1) * 20 }}{{queryString}}">{{page}}</a></li>
+                    <li class="page-item {{ 'current-page' if currentPage == page }}"><a class="page-link" href="/{{ owner }}?from={{ (page - 1) * 20 }}{{ query }}">{{page}}</a></li>
                     {% endif %}
 
                   {% endfor %}
                   <li class="page-item">
-                    <a class="page-link" href="/{{ owner }}?from={{ packages.summary.total - (packages.summary.total % 20) | int }}{{queryString}}" aria-label="Next">
+                    <a class="page-link" href="/{{ owner }}?from={{ packages.summary.total - (packages.summary.total % 20) | int }}{{ query }}" aria-label="Next">
                       <span aria-hidden="true">&raquo;</span>
                       <span class="sr-only">Next</span>
                     </a>

--- a/views/owner.html
+++ b/views/owner.html
@@ -73,7 +73,7 @@
               <nav aria-label="Datasets">
                 <ul class="pagination">
                   <li class="page-item">
-                    <a class="page-link" href="/{{ owner }}?from=0{{query}}" aria-label="Previous">
+                    <a class="page-link" href="/{{ owner }}?from=0{{queryString}}" aria-label="Previous">
                       <span aria-hidden="true">&laquo;</span>
                       <span class="sr-only">Previous</span>
                     </a>
@@ -82,12 +82,12 @@
                     {% if page == '...' %}
                     <li class="page-item disabled"><span class="page-link">{{page}}</span></li>
                     {% else %}
-                    <li class="page-item {{ 'current-page' if currentPage == page }}"><a class="page-link" href="/{{ owner }}?from={{ (page - 1) * 20 }}{{query}}">{{page}}</a></li>
+                    <li class="page-item {{ 'current-page' if currentPage == page }}"><a class="page-link" href="/{{ owner }}?from={{ (page - 1) * 20 }}{{queryString}}">{{page}}</a></li>
                     {% endif %}
 
                   {% endfor %}
                   <li class="page-item">
-                    <a class="page-link" href="/{{ owner }}?from={{ packages.summary.total - (packages.summary.total % 20) | int }}{{query}}" aria-label="Next">
+                    <a class="page-link" href="/{{ owner }}?from={{ packages.summary.total - (packages.summary.total % 20) | int }}{{queryString}}" aria-label="Next">
                       <span aria-hidden="true">&raquo;</span>
                       <span class="sr-only">Next</span>
                     </a>


### PR DESCRIPTION
After the last fix, if we pass query as a `query` variable, it appears on search button after clicking. So, renamed to `queryString`.
Please, see test output https://github.com/datahq/datahub-qa/issues/195