### PR TITLE
'Validate' page added.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "connect-flash": "^0.1.1",
     "cookie-parser": "^1.4.3",
     "cors": "^2.8.4",
+    "datapackage": "^1.0.6",
     "dotenv": "^4.0.0",
     "express": "^4.15.3",
     "express-ab": "^0.7.1",

--- a/routes/index.js
+++ b/routes/index.js
@@ -16,6 +16,7 @@ const config = require('../config')
 const lib = require('../lib')
 const utils = require('../lib/utils')
 
+const datapackage = require('datapackage')
 
 module.exports = function () {
   // eslint-disable-next-line new-cap
@@ -558,6 +559,34 @@ module.exports = function () {
       }
     }
   }
+
+  router.get('/tools/validate', async (req, res) => {
+    let dataset
+    let loading_error
+    let valid
+    let errors
+
+    if (req.query.q){
+      try {
+        dataset = await datapackage.Package.load(req.query.q)
+      } catch (err) {
+        loading_error = err
+      }
+    }
+
+    if (dataset){
+      valid = dataset.valid
+      errors = dataset.errors
+    }
+
+    res.render('validate.html', {
+      query: req.query.q,
+      dataset,
+      loading_error,
+      valid,
+      errors,
+    })
+  })
 
   router.get('/:owner/:name', renderShowcase('successful'))
   router.get('/:owner/:name/v/:revisionId', renderShowcase())

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -339,3 +339,31 @@ test('awesome non existing page returns 404', async t => {
   t.is(res.status, 200)
   t.true(res.text.includes('404'))
 })
+
+test('Validate page works', async t => {
+  const res = await request(app).get('/tools/validate')
+  t.is(res.status, 200)
+  t.true(res.text.includes('Data Package Validator'))
+})
+
+test('Validate shows Loading descriptor error', async t => {
+  const res = await request(app).get('/tools/validate?q=lalala')
+  t.is(res.status, 200)
+  t.true(res.text.includes('Error loading data package'))
+})
+
+test('Validate valid descriptor', async t => {
+  const query = '/tools/validate?q=https%3A%2F%2Fraw.githubusercontent.com%2Ffrictionlessdata%2Ftest-data%2Fmaster%2Fpackages%2Fbasic-csv%2Fdatapackage.json'
+  const res = await request(app).get(query)
+  t.is(res.status, 200)
+  t.true(res.text.includes('Descriptor is'))
+  t.true(res.text.includes('Valid'))
+})
+
+test('Validate invalid descriptor', async t => {
+  const query = '/tools/validate?q=https%3A%2F%2Fraw.githubusercontent.com%2Ffrictionlessdata%2Ftest-data%2Fmaster%2Fpackages%2Finvalid-descriptor%2Fdatapackage.json'
+  const res = await request(app).get(query)
+  t.is(res.status, 200)
+  t.true(res.text.includes('Descriptor is'))
+  t.true(res.text.includes('Invalid'))
+})

--- a/views/base.html
+++ b/views/base.html
@@ -67,6 +67,9 @@
                 <a href="/search">Datasets</a>
               </li>
               <li>
+                <a href="/tools/validate">Validate</a>
+              </li>
+              <li>
                 <a href="/awesome">Awesome</a>
               </li>
               <li>

--- a/views/owner.html
+++ b/views/owner.html
@@ -60,7 +60,7 @@
           </div>
           <div class="col-sm-6">
             <form class="search-form form form-inline" class="input-group col-xs-12" action="/{{ owner }}" method="GET">
-              <input type="text" class="form-control" placeholder="Search..." name="q" value="{{ queryString }}" required/>
+              <input type="text" class="form-control" placeholder="Search..." name="q" value="{{ queryString }}" required autofocus/>
             </form>
           </div>
         </div>

--- a/views/search.html
+++ b/views/search.html
@@ -17,7 +17,7 @@ Search Datasets
           Search for datasets
         </h1>
         <form class="search-form form form-inline" class="input-group col-xs-12" action="/search" method="GET">
-          <input type="text" class="form-control input-lg" placeholder="Search ..." name="q" value="{{ query }}" required/>
+          <input type="text" class="form-control input-lg" placeholder="Search ..." name="q" value="{{ query }}" required autofocus/>
           <button class="btn btn-primary" type="submit">Search</button>
         </form>
       </div>

--- a/views/validate.html
+++ b/views/validate.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+<!--{% import '_snippets.html' as snippets %}-->
+
+{% block title %}
+Validate Datasets
+{% endblock %}
+
+<!--{% block bodyclass %}search{% endblock %}-->
+
+{% block content %}
+<div class="container">
+    <div class="inner_container">
+        <div class="row">
+            <div class="col-md-7 col-md-offset-2 col-sm-12">
+                <h1>Data Package Validator</h1>
+                <form class="search-form form form-inline" class="input-group col-xs-12" action="/tools/validate" method="GET">
+                    <input type="text" class="form-control input-lg" placeholder="Paste link to your datapackage.json" name="q" value="{{ query }}" required autofocus/>
+                    <button class="btn btn-primary" type="submit">Validate</button>
+                </form>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-7 col-md-offset-2 col-sm-12">
+                {% if loading_error %}
+                    <h3>Error loading data package:</h3>
+                    {{ loading_error }}
+                {% endif %}
+
+                {% if dataset %}
+                    <h2>
+                        Descriptor is
+                        {% if valid == true %}
+                        Valid
+                        {% else %}
+                        Invalid
+                        {% endif %}
+                    </h2>
+                {% endif %}
+
+                {% if errors.length > 0 %}
+                    {{ errors }}
+                {% endif %}
+
+                {% if dataset %}
+                    <h3>Datapackage:</h3>
+                    <h4>Name: <strong>{{ dataset.descriptor.name }}</strong></h4>
+                    {% if dataset.descriptor.title %}
+                        <h4>Title: <strong>{{ dataset.descriptor.title }}</strong></h4>
+                    {% endif %}
+                    <h4>Resources:</h4>
+                    <ul>
+                        {% for name in dataset.resourceNames %}
+                        <li>{{name}}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
- http://datahub.io/tools/validate page implemented
  why 'tools'? - probably we'll have more online tools
- validation of the descriptor is performed using `datapackage-js`
- added a link from the main page
- added tests

@anuveyatsu could you also add some colors please, e.g.
- word 'Invalid' is red
- word 'Valid' is green
- red frame around errors
- name/title/resources is orange ?

Issues:
https://github.com/datahq/frontend/issues/253
https://github.com/datahq/pm/issues/142
https://github.com/datahq/datahub-qa/issues/200

Besides the issue:
- Autofocus on the search forms added (just improving UX a bit)